### PR TITLE
fix: Add displayName to forwardRef Turnstile mock to satisfy ESLint

### DIFF
--- a/src/app/contact/page.test.tsx
+++ b/src/app/contact/page.test.tsx
@@ -22,14 +22,16 @@ vi.mock('lucide-react', () => ({
 // Mock Turnstile — simulates widget already verified by default
 let onSuccessCallback: ((token: string) => void) | null = null;
 const mockTurnstileReset = vi.fn();
-vi.mock('@marsidev/react-turnstile', () => ({
+vi.mock('@marsidev/react-turnstile', () => {
   // Must use forwardRef so the component can call turnstileRef.current.reset()
-  Turnstile: React.forwardRef(({ onSuccess }: any, ref: any) => {
+  const Turnstile = React.forwardRef(({ onSuccess }: any, ref: any) => {
     onSuccessCallback = onSuccess;
     if (ref) ref.current = { reset: mockTurnstileReset };
     return <div data-testid="turnstile-widget" />;
-  }),
-}));
+  });
+  Turnstile.displayName = 'Turnstile';
+  return { Turnstile };
+});
 
 // Mock fetch for API calls
 const mockFetch = vi.fn();


### PR DESCRIPTION
## Summary

- Build failed on ESLint `react/display-name` rule: `React.forwardRef` inside `vi.mock` factory produced an anonymous component
- Extracted to a named `const Turnstile` and added `Turnstile.displayName = 'Turnstile'`
- No behaviour change — all 14 contact page tests still pass

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] Contact page tests pass (14/14)
- [ ] CI build step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)