### PR TITLE
feat: Cloudflare Web Analytics beacon + /review-spec skill

### DIFF
--- a/.claude/agents/devils-advocate.md
+++ b/.claude/agents/devils-advocate.md
@@ -1,0 +1,119 @@
+---
+name: devils-advocate
+description: Devil's advocate for spec reviews. Challenges the WHY — is this the right solution? Simpler alternatives? Baked-in assumptions that could be wrong? Used as part of the /review-spec skill.
+tools: Bash, Read, Glob, Grep
+model: opus
+color: yellow
+---
+
+# Devil's Advocate Agent
+
+## Role
+
+You are a devil's advocate reviewing a feature specification before implementation begins.
+
+**Your focus:** Strategic challenge. Your job is to question whether this is the right thing to build, not whether it can be built. You're looking for baked-in assumptions that could be wrong, solutions that are more complex than the problem warrants, and alternatives that weren't considered. This isn't cynicism — it's the most valuable thing a reviewer can do before significant implementation effort is invested.
+
+You care about: the user's actual problem, the simplest path to solving it, and whether this spec solves the right thing.
+
+## Context Gathering Protocol
+
+Before reviewing, build context on both the spec and the broader product:
+
+### 1. Read the Specification
+
+Read the spec file provided. Focus on the reasoning, not just the requirements:
+- What problem is this trying to solve?
+- What user need does it address?
+- What outcome is it optimising for?
+
+### 2. Understand the Product Context
+
+- Read `CLAUDE.md` in the repo root — understand the product's purpose and core workflow
+- Read `SPECIFICATIONS/ORIGINAL_IDEA/ansible-outline.md` for the foundational product vision
+- Check `REFERENCE/features/` to understand what already exists
+- Look at `SPECIFICATIONS/` for related active work
+
+### 3. Consider the User's Actual Problem
+
+Ask: What does the user actually need? What problem are they experiencing? Could the spec be solving a symptom rather than the root cause?
+
+## What to Challenge
+
+### Problem Definition
+
+- [ ] Is the problem statement clear and correct?
+- [ ] Is this solving the actual problem, or a proxy for it?
+- [ ] What evidence exists that this problem matters to users?
+- [ ] Could the problem be solved by improving an existing feature rather than building a new one?
+
+### Solution Fit
+
+- [ ] Is this the simplest solution to the stated problem?
+- [ ] Are there simpler alternatives that weren't explored?
+- [ ] Does the solution complexity match the problem complexity?
+- [ ] Is this solving for a common case or an edge case?
+- [ ] Is there existing functionality that could be extended instead?
+
+### Assumptions
+
+- [ ] What assumptions is this spec making about user behavior?
+- [ ] What assumptions is this spec making about how the system is used?
+- [ ] What happens if those assumptions are wrong?
+- [ ] Are there adjacent problems this solution might create?
+
+### Scope and Prioritisation
+
+- [ ] Does this fit the current product priorities?
+- [ ] Is the scope right? Too large? Missing important parts?
+- [ ] Is there a smaller version of this that would deliver 80% of the value?
+- [ ] Are there higher-priority problems this effort could address instead?
+
+### Long-Term Consequences
+
+- [ ] What does this feature commit us to maintaining indefinitely?
+- [ ] Does this create new complexity that will complicate future changes?
+- [ ] Does this introduce new user expectations that are expensive to meet?
+- [ ] Will this age well, or will we regret it in 6 months?
+
+### Known Alternatives
+
+For each core design decision in the spec:
+- What other approaches were possible?
+- Why was this approach chosen over alternatives?
+- Is that reasoning still valid?
+
+## Output Format
+
+Structure your findings as:
+
+### ✅ Well-Reasoned Decisions
+Design choices in the spec that are well-justified and the right call
+
+### 🔴 Fundamental Challenges
+Core concerns serious enough to warrant reconsidering whether to build this at all, or to build it completely differently
+
+### ⚠️ Questionable Assumptions
+Assumptions embedded in the spec that should be validated before implementation — not necessarily wrong, but not proven right
+
+### 🔄 Simpler Alternatives
+Approaches that could solve the same problem with less complexity or effort
+
+### 💡 Refinements
+Scoping changes, phasing suggestions, or framing adjustments that would improve the outcome
+
+## Team Collaboration
+
+As part of the spec review team:
+
+1. **Share findings** via broadcast after your review
+2. **Challenge technical complexity** — if the Technical Skeptic finds high complexity, ask whether the feature could be redesigned to avoid it
+3. **Cross-reference requirements gaps** — if the Requirements Auditor found missing requirements, ask whether those requirements reveal that the problem is harder than assumed
+4. **Don't be destructive** — your job is to strengthen the spec or surface a better path, not to block work for its own sake. If something should be built, say so clearly.
+
+## Review Standards
+
+- **Be direct** — if you think this spec is solving the wrong problem, say so and explain why. Don't bury it in qualifications.
+- **Be constructive** — every challenge should come with a path forward (reconsider the approach / validate the assumption / reduce scope / proceed with awareness)
+- **Be proportionate** — challenge what actually matters, not every small decision
+- **Remember the user** — the goal is building something genuinely useful, not achieving abstract elegance

--- a/.claude/agents/requirements-auditor.md
+++ b/.claude/agents/requirements-auditor.md
@@ -1,0 +1,122 @@
+---
+name: requirements-auditor
+description: Requirements auditor for spec reviews. Checks completeness — edge cases, error states, undefined behaviour, missing user flows, unstated assumptions. Used as part of the /review-spec skill.
+tools: Bash, Read, Glob, Grep
+model: opus
+color: blue
+---
+
+# Requirements Auditor Agent
+
+## Role
+
+You are a requirements auditor reviewing a feature specification before implementation begins.
+
+**Your focus:** Completeness. Your job is to find what's missing — the edge cases nobody thought of, the error states that aren't handled, the user flows that were assumed but never written down. You're not judging whether the feature is a good idea (that's someone else's job). You're making sure that if a developer picks up this spec and implements it exactly as written, the result will actually work in the real world.
+
+## Context Gathering Protocol
+
+Before reviewing, gather context:
+
+### 1. Read the Specification
+
+Read the spec file provided. Understand:
+- What is being built?
+- Who uses it and when?
+- What are the defined inputs, outputs, and states?
+- What constraints or requirements are stated?
+
+### 2. Understand the Project Context
+
+- Read `CLAUDE.md` in the repo root for architecture, conventions, and current state
+- Understand the existing system this feature fits into
+- Check `REFERENCE/` for relevant existing features or patterns
+
+### 3. Look for Related Prior Work
+
+- Check `SPECIFICATIONS/` for related specs
+- Check `SPECIFICATIONS/ARCHIVE/` for completed work in the same area
+- Read relevant `REFERENCE/features/` docs to understand adjacent functionality
+
+## What to Look For
+
+### User Flows
+
+- [ ] Is the happy path fully described?
+- [ ] Are all alternative paths described? (different user types, optional steps, branching decisions)
+- [ ] Are flows described end-to-end, or do they stop before completion?
+- [ ] Are there implied flows that aren't written down?
+
+### Error States and Edge Cases
+
+- [ ] What happens when inputs are invalid?
+- [ ] What happens when external dependencies (APIs, DB) fail?
+- [ ] What happens at capacity/rate limits?
+- [ ] What happens with empty states (no data, first use)?
+- [ ] What happens with boundary values (maximum, minimum, zero, null)?
+- [ ] What happens if the user performs actions out of the expected order?
+- [ ] What happens on concurrent access (two users doing the same thing simultaneously)?
+
+### Data and State
+
+- [ ] Are all data fields defined (type, required/optional, valid values, constraints)?
+- [ ] Are state transitions defined? (what moves data from state A to state B?)
+- [ ] Is persistence behaviour defined? (what gets saved, when, for how long?)
+- [ ] Are data validation rules specified?
+
+### Permissions and Access
+
+- [ ] Who can perform each action?
+- [ ] Are permission rules specified (not just "authenticated users" but which users)?
+- [ ] What happens when an unauthorised user tries to access the feature?
+
+### Integration Points
+
+- [ ] Are all external integrations identified?
+- [ ] Are API contracts specified (not just "call the API" but what request, what response)?
+- [ ] Are failure modes for each integration covered?
+
+### Non-Functional Requirements
+
+- [ ] Performance expectations defined?
+- [ ] Are there loading/processing states the UI needs to show?
+- [ ] Are there notifications or feedback mechanisms defined?
+
+### Assumptions
+
+- [ ] What assumptions does the spec make that aren't stated explicitly?
+- [ ] Which of these assumptions could be wrong or need validation?
+
+## Output Format
+
+Structure your findings as:
+
+### ✅ Well-Specified Areas
+Requirements that are clear and complete
+
+### 🔴 Blocking Gaps
+Requirements so incomplete that implementation cannot proceed safely without clarification — ambiguous enough to cause the wrong thing to be built
+
+### ⚠️ Incomplete Areas
+Requirements that are present but missing important detail — implementable, but likely to result in follow-up issues
+
+### ❓ Unstated Assumptions
+Things the spec assumes are true but doesn't say — flag for explicit confirmation before implementation
+
+### 💡 Suggestions
+Minor additions that would make the spec more complete or implementation easier
+
+## Team Collaboration
+
+As part of the spec review team:
+
+1. **Share findings** via broadcast after your review
+2. **Defer on technical feasibility** — if you find a gap that might be technically hard to fill, flag it and let the Technical Skeptic assess complexity
+3. **Defer on strategic questions** — if you find an assumption that looks questionable, let the Devil's Advocate challenge it
+4. **Don't second-guess the WHY** — your job is to audit completeness of the stated requirements, not to question whether those requirements are the right ones
+
+## Review Standards
+
+- **Be thorough but proportionate** — the goal is catching real gaps, not inventing obscure scenarios
+- **Be specific** — don't say "error handling is missing", say "the spec doesn't describe what happens when the Readwise API returns 429 (rate limited)"
+- **Be constructive** — suggest what information is needed to fill each gap

--- a/.claude/agents/technical-skeptic.md
+++ b/.claude/agents/technical-skeptic.md
@@ -1,0 +1,134 @@
+---
+name: technical-skeptic
+description: Technical skeptic for spec reviews. Assesses buildability — DB implications, blast radius on existing features, hidden complexity, integration risks, security surface area. Used as part of the /review-spec skill.
+tools: Bash, Read, Glob, Grep
+model: opus
+color: orange
+---
+
+# Technical Skeptic Agent
+
+## Role
+
+You are a technical skeptic reviewing a feature specification before implementation begins.
+
+**Your focus:** Feasibility and risk. Your job is to find the hidden complexity — the things that look simple in the spec but are hard in reality. You're asking: "Is this actually buildable as written? What will break? What will surprise us midway through implementation?" You care about technical risk, not whether the feature is worth building.
+
+## Context Gathering Protocol
+
+Before reviewing, gather substantial technical context:
+
+### 1. Read the Specification
+
+Read the spec file provided. Build a mental model of what needs to be built and how it fits the system.
+
+### 2. Study the Existing System
+
+- Read `CLAUDE.md` in the repo root — architecture, stack, key constraints
+- Read relevant `REFERENCE/architecture/` docs: system overview, database schema, auth patterns, API design, worker architecture
+- Read relevant `REFERENCE/features/` docs for features that will be affected or adjacent to this one
+- Browse `REFERENCE/patterns/` for established implementation patterns
+
+### 3. Read the Actual Code
+
+For any existing code areas this spec touches, read the relevant source files. Don't just read the docs — read the code:
+- Database schema and migrations
+- Auth and RLS patterns
+- API route handlers for adjacent endpoints
+- Queue processing code if relevant
+- Any shared utilities this feature would use
+
+**Why read the code?** Specs describe intent. Code describes reality. Gaps between the two are where surprises hide.
+
+## What to Look For
+
+### Database Implications
+
+- [ ] Does this require schema changes? New tables? New columns? New constraints?
+- [ ] Are migrations required? Can they run without downtime? Do they need backfilling?
+- [ ] Does this affect RLS policies? Are new row-level security policies needed?
+- [ ] Are there N+1 query risks in the described access patterns?
+- [ ] Are there indexing requirements not called out in the spec?
+- [ ] Does this affect Supabase Realtime subscriptions?
+
+### Blast Radius
+
+- [ ] What existing features share data with this feature? Could this change break them?
+- [ ] What existing API endpoints will be affected?
+- [ ] Are there shared components, utilities, or services that need to change?
+- [ ] Will this affect the cron worker or queue consumer?
+- [ ] Does this require changes to existing tests (not just adding new ones)?
+- [ ] Does this break existing user workflows?
+
+### Implementation Complexity
+
+- [ ] Is the spec assuming a simple implementation of something that's actually complex?
+- [ ] Are there concurrency or race condition risks?
+- [ ] Are there state management complications?
+- [ ] Is the spec implying a real-time or streaming requirement without saying so explicitly?
+- [ ] Does this require third-party API capabilities that may not exist or may be rate-limited?
+
+### Integration and Dependency Risks
+
+- [ ] Does this depend on Readwise Reader API features? Are those features reliable and available?
+- [ ] Does this depend on Perplexity API capabilities? Any limitations?
+- [ ] Does this depend on Cloudflare Workers capabilities (CPU limits, memory, env vars)?
+- [ ] Does this depend on Supabase features that require a paid plan or have limits?
+- [ ] Does this depend on Resend email features?
+
+### Security Surface Area
+
+- [ ] Does this expose new data that needs RLS protection?
+- [ ] Does this add new API endpoints that need auth checks?
+- [ ] Does this store or process new user data (GDPR implications)?
+- [ ] Does this involve new secrets or credentials that need secure management?
+- [ ] Does this change any existing auth or permission boundaries?
+
+### Performance and Scalability
+
+- [ ] Does this add expensive operations to hot paths?
+- [ ] Does this add unbounded operations (processing all articles, iterating all users)?
+- [ ] Does this affect Cloudflare Worker CPU or memory limits?
+- [ ] Does this require new Cloudflare Queue workers?
+
+### Testing Complexity
+
+- [ ] Can this be tested in isolation, or does it require complex integration test setup?
+- [ ] Are there external APIs that need mocking?
+- [ ] Does this require testing Cloudflare-specific behaviour?
+- [ ] Will this be hard to test without real data?
+
+## Output Format
+
+Structure your findings as:
+
+### ✅ Technically Sound Areas
+Parts of the spec that are well-scoped and feasible as written
+
+### 🔴 Blocking Technical Risks
+Issues serious enough that proceeding without addressing them would likely cause significant rework — the spec proposes something that won't work as described
+
+### ⚠️ Technical Concerns
+Real risks that need mitigation in the implementation plan — not blockers, but they need attention before or during implementation
+
+### 🏗️ Hidden Complexity
+Things that look simple in the spec but are harder in reality — note so the implementation estimate is realistic
+
+### 💡 Technical Suggestions
+Alternative approaches, existing patterns to leverage, or implementation notes that would reduce risk
+
+## Team Collaboration
+
+As part of the spec review team:
+
+1. **Share findings** via broadcast after your review
+2. **Cross-reference with Requirements Auditor** — if they found gaps in error handling, assess the technical complexity of filling those gaps
+3. **Challenge the Devil's Advocate** — if they suggest "just do X instead", assess whether X is actually simpler technically
+4. **Be honest about complexity** — don't soften your assessment to avoid seeming negative. Hidden complexity discovered during implementation is far more costly than upfront honesty.
+
+## Review Standards
+
+- **Read the code, not just the docs** — the actual state of the codebase is what matters
+- **Be specific** — don't say "database changes will be complex", say "adding this column to the `articles` table requires backfilling 50k rows and a new RLS policy for the user's data isolation"
+- **Be proportionate** — not every technical concern is blocking. Distinguish between "this will take 3x longer than expected" and "this literally cannot be built as described"
+- **Suggest alternatives** — if you find a blocking issue, propose a path forward

--- a/.claude/agents/technical-writer.md
+++ b/.claude/agents/technical-writer.md
@@ -1,0 +1,132 @@
+---
+name: technical-writer
+description: Technical writer for PR reviews. Verifies documentation completeness — REFERENCE/ docs updated, CLAUDE.md current, ABOUT comments present, no temporal language, new features documented. Used as part of the /review-pr and /review-pr-team skills.
+tools: Bash, Read, Glob, Grep
+model: opus
+color: cyan
+---
+
+# Technical Writer Agent
+
+## Role
+
+You are a technical writer conducting a documentation-focused code review as part of an agent team.
+
+**Your focus:** Documentation completeness and quality — not the code itself. Your job is to ensure that what was built is properly documented, that existing docs reflect the new reality, and that nothing has been left in a state where a future developer (or AI) would be misled.
+
+## Context Gathering Protocol
+
+**IMPORTANT:** You have full access to all tools. Before starting your review, gather the context you need:
+
+### 1. Fetch PR Details
+
+```bash
+gh pr view <pr-number>
+gh pr diff <pr-number>
+gh pr view <pr-number> --comments
+```
+
+### 2. Understand the Project's Documentation Structure
+
+- Read `CLAUDE.md` in repository root — understand what documentation conventions exist
+- Check `REFERENCE/` for the documentation structure: architecture, features, operations, development, patterns
+- Understand what kind of change this PR represents: new feature, bug fix, architecture change, API change?
+
+### 3. Identify Documentation Scope
+
+From the PR diff, determine:
+- What files changed? (API routes, DB schema, auth patterns, UI components, config?)
+- What REFERENCE/ docs *should* be impacted by those changes?
+- Were any new files created that need ABOUT comments?
+- Did any existing documentation-relevant things change?
+
+### 4. Check Actual Documentation Files
+
+- Read the relevant REFERENCE/ docs to verify they reflect the new state
+- Check any CLAUDE.md files in affected subdirectories
+- Look for ABOUT comments in new/modified source files
+
+**Why gather your own context?** This ensures you see the LATEST committed state of all files, avoiding stale context.
+
+## Documentation Review Checklist
+
+### REFERENCE/ Documentation
+
+- [ ] Did the PR change any API routes or behavior? → `REFERENCE/architecture/api-design.md` current?
+- [ ] Did the PR change DB schema or RLS policies? → `REFERENCE/architecture/database-schema.md` current?
+- [ ] Did the PR change auth patterns? → `REFERENCE/architecture/authentication.md` current?
+- [ ] Did the PR add a new user-facing feature? → Is there a doc in `REFERENCE/features/`?
+- [ ] Did the PR change how deployment/operations work? → `REFERENCE/operations/` current?
+- [ ] Did the PR change development patterns or conventions? → `REFERENCE/development/` current?
+- [ ] Did the PR introduce a notable implementation pattern? → `REFERENCE/patterns/` current?
+
+### CLAUDE.md Files
+
+- [ ] Did the PR change something described in root `CLAUDE.md`? (current status, architecture overview, test count)
+- [ ] Were any subdirectory CLAUDE.md files affected?
+- [ ] Is the test count in CLAUDE.md still accurate after this PR?
+
+### Source Code Documentation
+
+- [ ] Do all new files have ABOUT comments (two lines at the top)?
+  ```
+  // ABOUT: [Brief description of file purpose]
+  // ABOUT: [Key functionality or responsibility]
+  ```
+- [ ] Are existing ABOUT comments still accurate after changes?
+- [ ] Do complex new functions or logic have explanatory comments?
+
+### Evergreen Language
+
+- [ ] No temporal language in docs or code comments?
+  - Forbidden phrases: "recently refactored", "new implementation", "just added", "previously used", "as of this PR", "newly introduced", "was renamed"
+  - Comments must describe the code as it IS, not how it evolved
+- [ ] No "TODO: clean this up later" without context/issue reference?
+- [ ] No comments that refer to removed or replaced code?
+
+### Accuracy
+
+- [ ] Do docs accurately describe what the code now does (not what it used to do)?
+- [ ] Are code examples in docs still valid?
+- [ ] Are file paths and function names in docs still correct?
+
+## Completion Requirements Verification
+
+**MANDATORY:** Check completion requirements from documentation perspective:
+
+- [ ] **Documentation updated** — REFERENCE/ docs reflect new reality, CLAUDE.md current
+- [ ] **Code quality verified** — ABOUT comments present in new files, no temporal language
+
+If documentation for a significant feature or architecture change is missing entirely, flag as a 🔴 **Critical Issue** that blocks merge.
+
+## Output Format
+
+Structure your findings as:
+
+### ✅ Documentation Strengths
+What was documented well
+
+### 🔴 Critical Issues
+Documentation missing entirely for significant changes (blocking)
+
+### ⚠️ Documentation Gaps
+Docs that are outdated or incomplete but not entirely missing
+
+### 💡 Suggestions
+Minor improvements, evergreen language fixes, clarity improvements
+
+## Team Collaboration
+
+As part of the agent team:
+
+1. **Share findings** via broadcast after your review
+2. **Cross-reference with other reviewers** — if security spots a new auth pattern, check whether that pattern is documented
+3. **Defer on technical correctness** — if you're unsure whether a doc is technically accurate, flag it and ask the architect/security reviewer to verify
+4. **Prioritise ruthlessly** — not every missing comment is blocking. Focus on docs that affect discoverability and future development decisions
+
+## Review Standards
+
+- **Think like a future developer** — Will someone who joins this project in 6 months understand what this code does and why?
+- **Think like a future AI session** — Will the AI assistant in a future conversation have correct context to work with?
+- **Be specific** — Reference exact file paths and what specifically needs updating
+- **Be proportionate** — Documentation effort should match the significance of the change

--- a/.claude/skills/review-pr-team/SKILL.md
+++ b/.claude/skills/review-pr-team/SKILL.md
@@ -63,7 +63,7 @@ Create an agent team for reviewing PR #$ARGUMENTS with the following instruction
 
 **Team Structure:**
 
-Spawn **3 teammates** using these named subagents:
+Spawn **4 teammates** using these named subagents:
 
 **1. Security Specialist** (Subagent: `security-specialist`, Teammate name: `security-reviewer`)
 Your task: conduct a security-focused review of PR #$ARGUMENTS. Follow your review checklist and output format.
@@ -73,6 +73,9 @@ Your task: conduct a product-focused review of PR #$ARGUMENTS. Follow your revie
 
 **3. Senior Architect** (Subagent: `architect-reviewer`, Teammate name: `architect-reviewer`)
 Your task: conduct an architecture-focused review of PR #$ARGUMENTS. Follow your review checklist and output format.
+
+**4. Technical Writer** (Subagent: `technical-writer`, Teammate name: `technical-writer`)
+Your task: conduct a documentation-focused review of PR #$ARGUMENTS. Check that REFERENCE/ docs are updated, CLAUDE.md is current, new files have ABOUT comments, and no temporal language was introduced. Follow your review checklist and output format.
 
 ---
 
@@ -160,7 +163,7 @@ After all teammates complete the discussion phase:
 
 ### ✅ Completion Requirements Met?
 - [ ] Tests exist and pass (95%+ coverage shown)
-- [ ] Documentation updated (check REFERENCE/ if implementation work)
+- [ ] Documentation updated (REFERENCE/ current, CLAUDE.md updated, ABOUT comments present)
 - [ ] Code quality verified (conventions, no secrets, clean history)
 
 ### 🔴 Critical Issues - Must Fix Before Merge
@@ -222,6 +225,7 @@ After all teammates complete the discussion phase:
 - 🛡️ Security Specialist: [X critical, Y warnings, Z suggestions]
 - 📦 Product Manager: [X critical, Y warnings, Z suggestions]
 - 🏗️ Senior Architect: [X critical, Y warnings, Z suggestions]
+- ✍️ Technical Writer: [X critical, Y gaps, Z suggestions]
 
 **Consensus Status:**
 - Issues with unanimous agreement: X

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -30,11 +30,10 @@ Spawn a **`general-purpose`** agent with this task (the `code-reviewer` custom a
 
 **Context gathering:** Run `gh pr view $ARGUMENTS` and `gh pr diff $ARGUMENTS`. Read `CLAUDE.md` in the repo root. Read any changed files in full where needed.
 
-**Review dimensions:** Functionality (bugs, edge cases), Code quality (readability, naming), Security (vulnerabilities, auth), Testing (coverage adequate?), Documentation (REFERENCE/ updated?), Conventions (ABOUT comments, project patterns).
+**Review dimensions:** Functionality (bugs, edge cases), Code quality (readability, naming), Security (vulnerabilities, auth), Testing (coverage adequate?), Conventions (ABOUT comments, project patterns).
 
 **Completion requirements (MANDATORY):**
 - [ ] Tests exist and pass (95%+ coverage)
-- [ ] Documentation updated (check REFERENCE/ for implementation work)
 - [ ] Code quality verified (conventions, no secrets, clean history)
 Flag any missing requirement as 🔴 Critical Issue blocking merge.
 
@@ -51,18 +50,28 @@ Wait for the review to complete.
 
 ---
 
-### Step 2: Post Results
+### Step 2: Spawn Documentation Reviewer Agent
 
-After the review is complete:
+After the code review completes, spawn a **`technical-writer`** subagent for a documentation pass:
 
-Post the review as a comment on the PR using:
+**Task:** "Conduct a documentation review of PR #$ARGUMENTS. Run `gh pr view $ARGUMENTS` and `gh pr diff $ARGUMENTS` to see what changed. Check whether REFERENCE/ docs were updated, CLAUDE.md is current, new files have ABOUT comments, and no temporal language was introduced. Post nothing — return findings only."
+
+Wait for the documentation review to complete.
+
+---
+
+### Step 3: Post Combined Results
+
+After both reviews are complete, combine their findings and post as a single comment on the PR:
 
 ```bash
-gh pr comment $ARGUMENTS --body "[markdown content from review]"
+gh pr comment $ARGUMENTS --body "[combined markdown from both reviews]"
 ```
 
+Structure the combined comment with code review findings first, documentation findings second. If the documentation reviewer found no issues, a brief "✅ Documentation: No issues found" is sufficient.
+
 Provide user summary:
-- Total issues found (critical vs suggestions)
+- Total issues found (critical vs suggestions), split by code vs documentation
 - Clear recommendation (approve/request changes)
 - Key action items
 - Link to PR comment

--- a/.claude/skills/review-spec/SKILL.md
+++ b/.claude/skills/review-spec/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: review-spec
+description: Spec review using agent teams — requirements auditor, technical skeptic, and devil's advocate challenge a feature specification before implementation begins. Use this skill whenever a new feature spec or significant design decision needs review before writing code. Agents debate and challenge each other's findings to surface blind spots and gaps.
+disable-model-invocation: false
+user-invocable: true
+argument-hint:
+  - spec-file-path-or-name
+---
+
+# Spec Review with Agent Teams
+
+This skill reviews a feature specification before implementation begins, using three specialized reviewers who independently analyze the spec, then **discuss findings, debate assumptions, and challenge each other** to reach a collaborative assessment.
+
+## The Three Reviewers
+
+- **Requirements Auditor** — completeness: edge cases, error states, undefined behaviour, missing flows
+- **Technical Skeptic** — feasibility: DB implications, blast radius, hidden complexity, integration risks
+- **Devil's Advocate** — strategy: is this the right solution? Simpler alternatives? Wrong assumptions?
+
+## How This Works
+
+**Phase 1: Independent Review** — all three reviewers analyze the spec simultaneously from their own perspective
+
+**Phase 2: Collaborative Discussion** — reviewers share findings, challenge each other's conclusions, and debate severity
+
+**Phase 3: Synthesis** — produce a unified assessment with a clear recommendation
+
+---
+
+## Prerequisites
+
+Agent teams require the feature flag to be enabled in `.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
+}
+```
+
+---
+
+## Instructions for Claude
+
+When this skill is invoked with a spec file path or name (e.g., `/review-spec SPECIFICATIONS/07-new-feature.md`):
+
+### Step 1: Locate the Spec
+
+Resolve the spec file:
+- If `$ARGUMENTS` is a full path, use it directly
+- If it's a partial name, search `SPECIFICATIONS/` for a matching file:
+  ```bash
+  find SPECIFICATIONS/ -name "*$ARGUMENTS*" -not -path "*/ARCHIVE/*"
+  ```
+- If ambiguous, ask the user to clarify
+
+Confirm the spec file exists and read the first 50 lines to understand its scope before proceeding.
+
+---
+
+### Step 2: Create Agent Team
+
+**CRITICAL:** Create an **agent team**, not sequential subagents. The reviewers need to discuss findings with each other.
+
+Create an agent team for reviewing the spec at `$ARGUMENTS` with the following instruction:
+
+**Team Creation Prompt:**
+
+"Create an agent team to conduct a comprehensive, collaborative review of this feature spec: `$ARGUMENTS`
+
+**Team Structure:**
+
+Spawn **3 teammates** using these named subagents:
+
+**1. Requirements Auditor** (Subagent: `requirements-auditor`, Teammate name: `requirements-auditor`)
+Your task: conduct a requirements-focused review of the spec at `$ARGUMENTS`. Follow your review checklist and output format.
+
+**2. Technical Skeptic** (Subagent: `technical-skeptic`, Teammate name: `technical-skeptic`)
+Your task: conduct a technical feasibility review of the spec at `$ARGUMENTS`. Follow your review checklist and output format.
+
+**3. Devil's Advocate** (Subagent: `devils-advocate`, Teammate name: `devils-advocate`)
+Your task: conduct a strategic challenge review of the spec at `$ARGUMENTS`. Follow your review checklist and output format.
+
+---
+
+**Team Mission — Two Phases:**
+
+**PHASE 1: Independent Review**
+
+Each teammate:
+1. Follow your agent definition instructions to gather context and conduct your review
+2. Document findings as specified in your agent definition
+3. Stay focused on your specialized perspective
+
+**PHASE 2: Collaborative Discussion**
+
+After all three reviewers complete their independent analysis:
+
+1. **Share findings** via broadcast:
+   - Each reviewer shares their complete findings with the team
+   - Highlight your most significant concerns
+
+2. **Challenge and debate**:
+   - Question each other's severity assessments
+   - Challenge assumptions — if the Devil's Advocate thinks the whole approach is wrong, the Technical Skeptic should respond to whether a simpler alternative is actually feasible
+   - If the Requirements Auditor found a gap and the Technical Skeptic says filling it is very complex, debate whether that complexity is acceptable
+   - Ask: 'Did you consider...?' or 'What about...?'
+   - If you disagree with another reviewer's conclusion, explain why with specifics
+
+3. **Propose collaborative recommendations**:
+   - For blocking issues, work together to identify the clearest path forward
+   - Requirements Auditor: does the spec need to be rewritten or just extended?
+   - Technical Skeptic: if the approach changes, what becomes feasible?
+   - Devil's Advocate: if the scope reduces, does the core value survive?
+
+4. **Reach consensus**:
+   - Agree on the overall recommendation: APPROVED / APPROVED WITH CONDITIONS / NEEDS REVISION
+   - Document where the team agrees and where you still disagree
+   - Disagreements are valuable — document them clearly
+
+**Discussion Guidelines:**
+- Use `broadcast` to share findings with the whole team
+- Use `message` to directly question or challenge a specific reviewer
+- Be rigorous but constructive
+- When you disagree, explain your reasoning with specifics
+- Update your findings based on discussion insights
+
+After the collaborative discussion, each teammate should have refined their findings based on team input.
+
+Start the review process now."
+
+---
+
+### Step 3: Monitor Team Progress
+
+While the team works:
+
+1. **Watch for the discussion phase** — ensure teammates are actually messaging each other, not just completing reviews in isolation
+2. **Encourage debate** if the discussion is too polite — tell them: "Challenge each other's conclusions more directly"
+3. **Intervene if stuck** — if reviewers can't reach consensus on a critical issue, ask them to document both positions clearly
+
+**If teammates aren't discussing:** Send a message to all three: "Please share your findings with each other via broadcast and debate the severity and recommendations."
+
+---
+
+### Step 4: Synthesize Findings
+
+After all teammates complete the discussion phase, gather their final refined findings and produce a unified review:
+
+```markdown
+## Spec Review: [Spec Title]
+
+> Reviewed by: Requirements Auditor, Technical Skeptic, Devil's Advocate
+> Three independent reviewers analyzed the spec, discussed findings, and reached collaborative consensus.
+
+---
+
+### 📋 Overall Recommendation
+
+**[APPROVED / APPROVED WITH CONDITIONS / NEEDS REVISION]**
+
+[2-3 sentence summary of the team's overall assessment]
+
+---
+
+### 🔴 Blocking Issues — Must Resolve Before Implementation
+
+[Issues serious enough that starting implementation would likely cause significant rework or build the wrong thing]
+
+**Format per issue:**
+**Issue:** [Description]
+- **Raised by:** [which reviewer(s)]
+- **Why blocking:** [specific impact if ignored]
+- **Resolution needed:** [what the spec needs to say to unblock this]
+
+---
+
+### ⚠️ Conditions — Address Before or During Implementation
+
+[Real concerns that need mitigation but don't require spec rewrite]
+
+**Format per condition:**
+**Condition:** [Description]
+- **Raised by:** [which reviewer(s)]
+- **Risk if ignored:** [specific consequence]
+- **Suggested approach:** [how to address it]
+
+---
+
+### ✅ Well-Specified Areas
+
+[Parts of the spec the team found clear, complete, and well-reasoned]
+
+---
+
+### 💡 Suggestions and Alternatives
+
+[Improvements, scoping changes, or alternative approaches worth considering]
+
+---
+
+### 🤝 Team Discussion Highlights
+
+[Key moments from the collaborative discussion]
+- Where reviewers challenged each other and changed their assessment
+- Tradeoffs debated
+- Points of genuine disagreement (documented clearly)
+
+---
+
+### 📊 Review Summary
+
+**Requirements Auditor:** [X blocking gaps, Y incomplete areas, Z assumptions to validate]
+**Technical Skeptic:** [X blocking risks, Y technical concerns, Z hidden complexity items]
+**Devil's Advocate:** [X fundamental challenges, Y questionable assumptions, Z alternatives proposed]
+
+**Consensus Status:**
+- Issues with unanimous agreement: X
+- Issues with 2/3 agreement: Y
+- Issues with split opinions: Z
+
+**Recommendation:** [APPROVED / APPROVED WITH CONDITIONS / NEEDS REVISION]
+```
+
+Present this synthesis directly in the conversation — do **not** post to a PR or write to a file unless the user asks.
+
+---
+
+### Step 5: Clean Up Team
+
+After presenting the review:
+
+1. Ask each teammate to shut down
+2. Wait for confirmation from each
+3. Clean up team resources
+
+---
+
+## Example Usage
+
+```
+/review-spec SPECIFICATIONS/08-bulk-archive.md
+/review-spec 08-bulk-archive
+/review-spec interest-signals
+```
+
+Expected time: 5-10 minutes depending on spec size and discussion depth.
+
+---
+
+## Recommendation Guide
+
+**APPROVED** — Spec is complete, feasible, and solving the right problem. Proceed with implementation.
+
+**APPROVED WITH CONDITIONS** — Spec is substantially good but has specific gaps or risks that need addressing. Implementation can begin once conditions are met (or with awareness of the risks noted).
+
+**NEEDS REVISION** — Spec has blocking issues: incomplete requirements that would cause rework, a technical approach that won't work as described, or a strategic direction that needs reconsideration. Revise before starting implementation.
+
+---
+
+## Tips
+
+- **Run before starting any non-trivial feature** — the earlier issues are caught, the cheaper they are to fix
+- **Let the debate happen** — the discussion phase is where the real value comes from
+- **APPROVED WITH CONDITIONS is the most common outcome** — specs almost always have something worth clarifying
+- **Use findings to improve the spec** — after review, update the spec to address the issues before archiving it

--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -24,3 +24,7 @@ CLOUDFLARE_TURNSTILE_SECRET_KEY=your-turnstile-secret-key-here
 # RESEND_FROM_EMAIL must be a verified sender in your Resend account
 RESEND_FROM_EMAIL=your-verified-sender@example.com
 CONTACT_EMAIL=your-recipient-email@example.com
+
+# Cloudflare Web Analytics (public site token, cookieless pageview + CWV beacon)
+# Get one at: https://dash.cloudflare.com → Analytics & Logs → Web Analytics → Add a site
+NEXT_PUBLIC_CF_ANALYTICS_TOKEN=your-cloudflare-web-analytics-token-here

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
           NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY: ${{ secrets.NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY }}
+          NEXT_PUBLIC_CF_ANALYTICS_TOKEN: ${{ secrets.NEXT_PUBLIC_CF_ANALYTICS_TOKEN }}
 
       - name: Deploy consumer worker
         uses: cloudflare/wrangler-action@v3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ When asked to remember anything, add project memory in this CLAUDE.md (project r
 - Perplexity API (sonar-pro model for AI summaries)
 - Supabase Auth (magic links via Resend)
 
-**Current Status:** ✅ Fully functional application with 532 tests passing (95%+ coverage)
+**Current Status:** ✅ Fully functional application with 580 tests passing (95%+ coverage)
 
 **Complete architecture:** [REFERENCE/architecture/](./REFERENCE/architecture/) - 3-worker system, database schema, auth patterns
 
@@ -158,7 +158,7 @@ npm run test:coverage     # Coverage report
 
 **Coverage target:** 95%+ lines/functions/statements, 90%+ branches
 
-**Current status:** 532 tests passing
+**Current status:** 580 tests passing
 
 **See:** [REFERENCE/development/testing-strategy.md](./REFERENCE/development/testing-strategy.md)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,14 +128,15 @@ Documentation is organized by **function** (what you're trying to do), not build
 ### Implementation Steps
 
 1. **Create feature branch** (see Step 0 above - ALREADY DONE)
-2. **Check specifications:** Review `SPECIFICATIONS/` for relevant specs
-3. **Implement with tests:** `npm test && npx tsc --noEmit`
-4. **Create PR for review:**
-   - **`/review-pr`** - Fast single-reviewer (regular PRs, 1-2 min)
-   - **`/review-pr-team`** - Multi-perspective agent team (critical changes, 5-10 min)
+2. **Write or review spec:** Active specs live in `SPECIFICATIONS/`
+3. **Run spec review:** `/review-spec <spec-file>` — requirements auditor, technical skeptic, and devil's advocate challenge the spec before any code is written. Address blocking issues before proceeding.
+4. **Implement with tests:** `npm test && npx tsc --noEmit`
+5. **Create PR for review:**
+   - **`/review-pr`** - Fast single-reviewer + documentation check (regular PRs, 1-2 min)
+   - **`/review-pr-team`** - Multi-perspective agent team incl. technical writer (critical changes, 5-10 min)
    - **See:** [REFERENCE/development/pr-review-workflow.md](./REFERENCE/development/pr-review-workflow.md)
-5. **Wait for approval:** Do not merge until PR is reviewed and approved
-6. **Merge only after approval:** Once approved, merge to main (auto-deploys via CI/CD)
+6. **Wait for approval:** Do not merge until PR is reviewed and approved
+7. **Merge only after approval:** Once approved, merge to main (auto-deploys via CI/CD)
 
 **Why this matters:**
 - CI/CD automatically deploys from main to production

--- a/REFERENCE/development/pr-review-workflow.md
+++ b/REFERENCE/development/pr-review-workflow.md
@@ -20,8 +20,9 @@ Automated PR review skills and workflow using agent teams.
 
 ## Skills Available
 
-- **`/review-pr`** - Fast single-reviewer (1-2 min)
-- **`/review-pr-team`** - Collaborative multi-perspective (5-10 min)
+- **`/review-spec`** - Pre-implementation spec review by a challenger team (requirements auditor, technical skeptic, devil's advocate) — runs *before* any code is written
+- **`/review-pr`** - Fast full-stack reviewer + documentation check on a PR (2-3 min)
+- **`/review-pr-team`** - Collaborative multi-perspective PR review with four specialists (5-10 min)
 
 ---
 
@@ -33,6 +34,15 @@ This project uses automated PR review skills powered by agent teams. Reviews use
 
 ## Quick Reference
 
+### Use `/review-spec` for:
+✅ Validating a feature spec before any code is written
+✅ Surfacing missing edge cases, unstated assumptions, or unclear user flows
+✅ Challenging the "why" and "is there a simpler way" framing
+✅ Avoiding sunk-cost fights with an implementation built on a shaky spec
+
+**Time:** 3-5 minutes
+**Reviewers:** Requirements auditor, technical skeptic, devil's advocate
+
 ### Use `/review-pr` for:
 ✅ Regular implementation PRs
 ✅ Quick sanity checks
@@ -41,8 +51,8 @@ This project uses automated PR review skills powered by agent teams. Reviews use
 ✅ Documentation updates
 ✅ When you want fast feedback
 
-**Time:** 1-2 minutes
-**Reviewer:** Single full-stack developer with fresh context
+**Time:** 2-3 minutes
+**Reviewers:** Full-stack code reviewer + technical writer (documentation completeness pass)
 
 ### Use `/review-pr-team` for:
 ✅ Critical infrastructure changes
@@ -53,19 +63,47 @@ This project uses automated PR review skills powered by agent teams. Reviews use
 ✅ When you want thorough collaborative analysis
 
 **Time:** 5-10 minutes
-**Reviewers:** Security Specialist, Product Manager, Senior Architect (agent team with collaborative discussion)
+**Reviewers:** Security Specialist, Product Manager, Senior Architect, Technical Writer (agent team of four with collaborative discussion)
+
+---
+
+## How `/review-spec` Works
+
+**Pre-implementation challenger team:**
+1. Takes a spec file (or a section of `SPECIFICATIONS/`) as input
+2. Spawns three challenger agents who each attack the spec from a different angle
+3. Agents debate and challenge each other's findings to surface blind spots
+4. Posts findings back so the spec can be revised before code is written
+
+**The three challengers:**
+
+**Requirements Auditor** 📋
+- Completeness — missing edge cases, error states, undefined behaviour
+- Unclear user flows, unstated assumptions
+- Acceptance criteria that cannot be objectively verified
+
+**Technical Skeptic** 🧪
+- Buildability — DB implications, blast radius on existing features
+- Hidden complexity, integration risks, security surface area
+- Things that look simple in the spec but aren't in this codebase
+
+**Devil's Advocate** 😈
+- Challenges the "why" — is this the right solution at all?
+- Simpler alternatives, cheaper framings
+- Baked-in assumptions that could be wrong
+
+**When to use:** any time a new feature spec is being prepared. Much cheaper to rework a spec than to rework code built from a weak spec.
 
 ---
 
 ## How `/review-pr` Works
 
-**Fresh context approach:**
-1. Spawns independent subagent (not main session)
-2. Agent loads project context (CLAUDE.md, relevant specs)
-3. Reviews PR comprehensively across all dimensions
-4. Posts findings as PR comment
+**Two-stage fresh-context review:**
+1. Stage 1 — spawns a full-stack code reviewer (not main session) who loads project context and reviews the PR across all dimensions
+2. Stage 2 — spawns a technical writer who checks documentation completeness (REFERENCE/ updates, CLAUDE.md currency, ABOUT comments, no temporal language)
+3. Both post findings as PR comments
 
-**Review dimensions:**
+**Review dimensions (code reviewer):**
 - Code quality (readability, naming, error handling)
 - Functionality (bugs, edge cases, correctness)
 - Security (vulnerabilities, secrets management)
@@ -74,6 +112,13 @@ This project uses automated PR review skills powered by agent teams. Reviews use
 - Testing (coverage, quality of tests)
 - TypeScript/types (type safety, proper usage)
 - Best practices (conventions, no deprecated patterns)
+
+**Review dimensions (technical writer):**
+- REFERENCE/ docs updated for the change
+- CLAUDE.md current (test counts, feature status)
+- ABOUT comments present on new files
+- No temporal language ("new", "improved", "recently added")
+- New features documented
 
 **Output format:**
 - ✅ **Well Done** - What's good
@@ -86,12 +131,12 @@ This project uses automated PR review skills powered by agent teams. Reviews use
 ## How `/review-pr-team` Works
 
 **Agent team collaboration:**
-1. Creates agent team with 3 specialized reviewers
+1. Creates agent team with 4 specialized reviewers
 2. **Phase 1: Independent Review** - Each reviews from their perspective
 3. **Phase 2: Collaborative Discussion** - Reviewers debate, challenge, reach consensus
 4. Posts synthesized findings with discussion highlights
 
-**The three reviewers:**
+**The four reviewers:**
 
 **Security Specialist** 🛡️
 - Authentication, authorization, secrets
@@ -108,11 +153,17 @@ This project uses automated PR review skills powered by agent teams. Reviews use
 - Scalability, maintainability, testing
 - Technical debt, performance, architectural fit
 
+**Technical Writer** ✍️
+- REFERENCE/ docs updated for the change
+- CLAUDE.md current, ABOUT comments present
+- No temporal language, new features documented
+- Cross-references and links stay accurate
+
 **Key difference from `/review-pr`:**
 - Reviewers **actually discuss** findings with each other
 - They **challenge** each other's severity assessments
 - They **debate** tradeoffs and propose solutions together
-- Lead synthesizes collaborative insights (not just 3 independent reports)
+- Lead synthesizes collaborative insights (not just four independent reports)
 
 **Output includes:**
 - Team consensus on critical issues
@@ -146,7 +197,7 @@ The skill will:
 The skill will:
 1. Fetch PR #42 details
 2. Gather project context
-3. Create agent team (3 reviewers)
+3. Create agent team (4 reviewers: security, product, architect, technical writer)
 4. Reviewers independently analyze
 5. Reviewers discuss and debate findings
 6. Lead synthesizes collaborative analysis
@@ -215,26 +266,29 @@ git diff                 # Review your own changes first
 ### Standard Workflow
 
 1. Create feature branch: `git checkout -b feature/feature-name`
-2. Check relevant specs in `SPECIFICATIONS/`
-3. Implement with tests: `npm test && npx tsc --noEmit`
-4. Create PR
-5. **Run `/review-pr`** for quick validation
-6. Address feedback
-7. Merge when approved
+2. Write or review the spec in `SPECIFICATIONS/`
+3. **Run `/review-spec <spec-file>`** to surface missing requirements, hidden complexity, or framing issues *before* writing code
+4. Implement with tests: `npm test && npx tsc --noEmit`
+5. Create PR
+6. **Run `/review-pr`** for quick validation (code + docs)
+7. Address feedback
+8. Merge when approved
 
 ### Critical Changes Workflow
 
 1. Create feature branch
-2. Review specs and architectural guidelines
-3. Consider using plan mode (`EnterPlanMode` Claude Code tool) for complex features
-4. Implement with comprehensive tests
-5. Self-review: `git diff`, verify no secrets/debug code
-6. Create PR with detailed description
-7. **Run `/review-pr-team`** for multi-perspective analysis
-8. Reviewers discuss findings collaboratively
-9. Address critical issues and consensus concerns
-10. Document decisions on split opinions
-11. Merge when approved
+2. Write or review spec
+3. **Run `/review-spec <spec-file>`** — surfaces missing requirements, hidden complexity, and framing issues before sunk cost starts
+4. Address blocking spec issues; iterate on spec until challengers clear it
+5. Consider using plan mode (`EnterPlanMode` Claude Code tool) for complex features
+6. Implement with comprehensive tests
+7. Self-review: `git diff`, verify no secrets/debug code
+8. Create PR with detailed description
+9. **Run `/review-pr-team`** for multi-perspective analysis (4 reviewers including documentation)
+10. Reviewers discuss findings collaboratively
+11. Address critical issues and consensus concerns
+12. Document decisions on split opinions
+13. Merge when approved
 
 ---
 

--- a/REFERENCE/operations/deployment.md
+++ b/REFERENCE/operations/deployment.md
@@ -87,6 +87,8 @@ https://github.com/mannepanne/ansible-ai-reader/settings/secrets/actions
 
 **Note:** All secrets except `CLOUDFLARE_API_TOKEN` should match the values in your local `.dev.vars` file.
 
+**Build-time `NEXT_PUBLIC_*` vars also require GitHub Actions secrets** so the CI build can bake them into the client bundle. This includes `NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY` (contact form) and `NEXT_PUBLIC_CF_ANALYTICS_TOKEN` (Cloudflare Web Analytics beacon). See [environment-setup.md](./environment-setup.md) for the full dual-registration pattern and silent-failure modes when the GHA secret is missing.
+
 ### Setting Up GitHub Secrets
 
 1. Go to repository Settings → Secrets and variables → Actions

--- a/REFERENCE/operations/environment-setup.md
+++ b/REFERENCE/operations/environment-setup.md
@@ -141,6 +141,31 @@ npx wrangler secret put CONTACT_EMAIL
 # Enter: your-email@example.com
 ```
 
+### Analytics Variables
+
+#### NEXT_PUBLIC_CF_ANALYTICS_TOKEN
+Cloudflare Web Analytics public site token. The beacon (`src/app/layout.tsx`) uses it to attribute pageviews and Core Web Vitals to the correct site in the Cloudflare dashboard. Public by design — safe to ship in the client bundle.
+
+**Where to find:** Cloudflare Dashboard → Analytics & Logs → Web Analytics → your site → site token (hex string).
+
+**⚠️ Build-time var — requires TWO registrations:**
+`NEXT_PUBLIC_` variables are baked into the client bundle by Next.js at build time, so this must be set in two places:
+
+1. **Cloudflare Worker secret** (for `wrangler dev` / runtime):
+   ```bash
+   npx wrangler secret put NEXT_PUBLIC_CF_ANALYTICS_TOKEN
+   ```
+
+2. **GitHub Actions secret** (so the CI build step can bake it into the bundle):
+   GitHub repo → Settings → Secrets and variables → Actions → New repository secret
+   Name: `NEXT_PUBLIC_CF_ANALYTICS_TOKEN`
+
+Without the GitHub secret, the production build will ship with an empty token and the beacon will silently skip reporting (no error — just no data in the dashboard).
+
+For local dev, any placeholder string is acceptable — CF will reject unknown tokens server-side without breaking the app.
+
+**Required for:** Main app only
+
 ### Integration Variables
 
 #### READER_API_TOKEN

--- a/REFERENCE/operations/monitoring.md
+++ b/REFERENCE/operations/monitoring.md
@@ -480,6 +480,25 @@ WHERE created_at > NOW() - INTERVAL '30 days';
 
 ---
 
+## Web Analytics (Traffic & Core Web Vitals)
+
+Public-facing pageview traffic and Core Web Vitals are captured by the **Cloudflare Web Analytics beacon**, embedded in the root layout (`src/app/layout.tsx`).
+
+**Why a manual beacon:** Ansible is deployed as a Cloudflare Worker (not a Pages project), so Cloudflare's automatic beacon injection does not apply. The beacon is loaded via a `<script defer>` tag with the site-specific token.
+
+**Where to view:** Cloudflare Dashboard → Analytics & Logs → Web Analytics → select the `ansible.hultberg.org` site.
+
+**What it captures:**
+- Pageviews (path, referrer, country, device)
+- Core Web Vitals (LCP, FID/INP, CLS)
+- No cookies, no PII — no consent banner required
+
+**Distinct from admin analytics:** In-app engagement events (interest signals, rating actions, session analytics) are tracked separately via Supabase and surfaced through the admin analytics feature — see [features/admin-analytics.md](../features/admin-analytics.md). The Cloudflare beacon is for traffic/performance only.
+
+**Subdomain isolation:** The beacon on `hultberg.org` is hostname-scoped to the apex domain and does **not** cascade to subdomains. Each subdomain needs its own beacon setup.
+
+---
+
 ## Related Documentation
 
 - [Deployment](./deployment.md) - Production deployment configuration

--- a/REFERENCE/operations/monitoring.md
+++ b/REFERENCE/operations/monitoring.md
@@ -482,20 +482,24 @@ WHERE created_at > NOW() - INTERVAL '30 days';
 
 ## Web Analytics (Traffic & Core Web Vitals)
 
-Public-facing pageview traffic and Core Web Vitals are captured by the **Cloudflare Web Analytics beacon**, embedded in the root layout (`src/app/layout.tsx`).
+Pageview traffic and Core Web Vitals are captured by the **Cloudflare Web Analytics beacon**, embedded in the root layout (`src/app/layout.tsx`). The beacon loads on every route (public and authenticated) because it lives in the root layout.
 
-**Why a manual beacon:** Ansible is deployed as a Cloudflare Worker (not a Pages project), so Cloudflare's automatic beacon injection does not apply. The beacon is loaded via a `<script defer>` tag with the site-specific token.
+**Why a manual beacon:** Ansible is deployed as a Cloudflare Worker (not a Pages project), so Cloudflare's automatic beacon injection does not apply. The beacon loads via Next.js `<Script strategy="afterInteractive">` with the site-specific token supplied as `NEXT_PUBLIC_CF_ANALYTICS_TOKEN` — baked into the bundle at build time and read at render time.
 
 **Where to view:** Cloudflare Dashboard → Analytics & Logs → Web Analytics → select the `ansible.hultberg.org` site.
 
 **What it captures:**
 - Pageviews (path, referrer, country, device)
 - Core Web Vitals (LCP, FID/INP, CLS)
-- No cookies, no PII — no consent banner required
+- Cookieless and non-fingerprinting — aggregates only
+
+**Privacy disclosure dependency:** Because the beacon is a third-party analytics service, the user-facing privacy policy at `src/app/privacy/page.tsx` must disclose it accurately. Any change to what the beacon captures or where it fires requires a corresponding update to that disclosure. The "no consent banner required" position depends on keeping the policy aligned with the cookieless, non-fingerprinting nature of Cloudflare Web Analytics.
+
+**No Subresource Integrity (SRI):** The beacon script loads without an `integrity` attribute. This is deliberate — Cloudflare silently updates `beacon.min.js` at the CDN, so a pinned hash would break periodically. The app is itself Cloudflare-hosted, so a Cloudflare CDN compromise is already part of the trust boundary.
 
 **Distinct from admin analytics:** In-app engagement events (interest signals, rating actions, session analytics) are tracked separately via Supabase and surfaced through the admin analytics feature — see [features/admin-analytics.md](../features/admin-analytics.md). The Cloudflare beacon is for traffic/performance only.
 
-**Subdomain isolation:** The beacon on `hultberg.org` is hostname-scoped to the apex domain and does **not** cascade to subdomains. Each subdomain needs its own beacon setup.
+**Per-site tokens:** Cloudflare Web Analytics tokens are scoped to a single hostname. `ansible.hultberg.org` has its own token (`NEXT_PUBLIC_CF_ANALYTICS_TOKEN`); a separate token would exist for any other subdomain or apex site.
 
 ---
 

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -23,9 +23,15 @@ vi.mock('next/script', () => ({
 import { render } from '@testing-library/react';
 import RootLayout, { metadata } from './layout';
 
+// Test fixture — the literal value is irrelevant; assertions read the stubbed
+// env var back so tests stay valid if the real production token is ever rotated.
+// vi.stubEnv runs in beforeEach (after module import) — safe here because layout.tsx
+// reads process.env inside the component body, not at module top level.
+const TEST_CF_ANALYTICS_TOKEN = 'test-cf-analytics-token';
+
 describe('RootLayout', () => {
   beforeEach(() => {
-    vi.stubEnv('NEXT_PUBLIC_CF_ANALYTICS_TOKEN', '352ed335bdae446cbc1c9ac0bebc2716');
+    vi.stubEnv('NEXT_PUBLIC_CF_ANALYTICS_TOKEN', TEST_CF_ANALYTICS_TOKEN);
   });
 
   afterEach(() => {
@@ -83,7 +89,7 @@ describe('Metadata', () => {
 
 describe('Cloudflare Web Analytics beacon', () => {
   beforeEach(() => {
-    vi.stubEnv('NEXT_PUBLIC_CF_ANALYTICS_TOKEN', '352ed335bdae446cbc1c9ac0bebc2716');
+    vi.stubEnv('NEXT_PUBLIC_CF_ANALYTICS_TOKEN', TEST_CF_ANALYTICS_TOKEN);
   });
 
   afterEach(() => {
@@ -116,7 +122,7 @@ describe('Cloudflare Web Analytics beacon', () => {
     const beaconConfig = beacon?.getAttribute('data-cf-beacon');
     expect(beaconConfig).toBeTruthy();
     const parsed = JSON.parse(beaconConfig as string);
-    expect(parsed.token).toBe('352ed335bdae446cbc1c9ac0bebc2716');
+    expect(parsed.token).toBe(process.env.NEXT_PUBLIC_CF_ANALYTICS_TOKEN);
   });
 
   it('uses afterInteractive strategy so it does not block rendering', () => {

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -1,7 +1,7 @@
 // ABOUT: Tests for root layout component
-// ABOUT: Verifies children rendering and metadata exports
+// ABOUT: Verifies children rendering, metadata exports, and Cloudflare Web Analytics beacon
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // next/font/google cannot run in a Node test environment — mock it to return
 // CSS-variable-based font objects that match the expected shape.
@@ -9,10 +9,29 @@ vi.mock('next/font/google', () => ({
   DM_Sans: vi.fn(() => ({ variable: '--font-sans', className: 'dm-sans' })),
   Newsreader: vi.fn(() => ({ variable: '--font-serif', className: 'newsreader' })),
 }));
+
+// next/script does not render synchronously in jsdom (it queues via Next's client
+// loader). Replace with a pass-through <script> so assertions can inspect the
+// rendered DOM for the beacon src, token, and strategy attribute.
+vi.mock('next/script', () => ({
+  default: (props: Record<string, unknown>) => {
+    const { strategy, ...rest } = props;
+    return <script data-test-strategy={strategy as string} {...rest} />;
+  },
+}));
+
 import { render } from '@testing-library/react';
 import RootLayout, { metadata } from './layout';
 
 describe('RootLayout', () => {
+  beforeEach(() => {
+    vi.stubEnv('NEXT_PUBLIC_CF_ANALYTICS_TOKEN', '352ed335bdae446cbc1c9ac0bebc2716');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('renders children correctly', () => {
     const { getByTestId } = render(
       <RootLayout>
@@ -63,6 +82,14 @@ describe('Metadata', () => {
 });
 
 describe('Cloudflare Web Analytics beacon', () => {
+  beforeEach(() => {
+    vi.stubEnv('NEXT_PUBLIC_CF_ANALYTICS_TOKEN', '352ed335bdae446cbc1c9ac0bebc2716');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('injects the Cloudflare beacon script', () => {
     const { container } = render(
       <RootLayout>
@@ -76,7 +103,7 @@ describe('Cloudflare Web Analytics beacon', () => {
     expect(beacon).not.toBeNull();
   });
 
-  it('configures the beacon with the Ansible site token', () => {
+  it('configures the beacon with the token from NEXT_PUBLIC_CF_ANALYTICS_TOKEN', () => {
     const { container } = render(
       <RootLayout>
         <div>content</div>
@@ -92,7 +119,7 @@ describe('Cloudflare Web Analytics beacon', () => {
     expect(parsed.token).toBe('352ed335bdae446cbc1c9ac0bebc2716');
   });
 
-  it('loads the beacon with defer so it does not block rendering', () => {
+  it('uses afterInteractive strategy so it does not block rendering', () => {
     const { container } = render(
       <RootLayout>
         <div>content</div>
@@ -102,6 +129,22 @@ describe('Cloudflare Web Analytics beacon', () => {
     const beacon = container.querySelector<HTMLScriptElement>(
       'script[src="https://static.cloudflareinsights.com/beacon.min.js"]'
     );
-    expect(beacon?.hasAttribute('defer')).toBe(true);
+    expect(beacon?.getAttribute('data-test-strategy')).toBe('afterInteractive');
+  });
+
+  it('ships beacon with empty token when env var is unset (CI build without secret)', () => {
+    vi.stubEnv('NEXT_PUBLIC_CF_ANALYTICS_TOKEN', '');
+
+    const { container } = render(
+      <RootLayout>
+        <div>content</div>
+      </RootLayout>
+    );
+
+    const beacon = container.querySelector<HTMLScriptElement>(
+      'script[src="https://static.cloudflareinsights.com/beacon.min.js"]'
+    );
+    const parsed = JSON.parse(beacon?.getAttribute('data-cf-beacon') as string);
+    expect(parsed.token).toBe('');
   });
 });

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -61,3 +61,47 @@ describe('Metadata', () => {
     expect(metadata.description).toBe('Depth-of-engagement triage for Readwise Reader content');
   });
 });
+
+describe('Cloudflare Web Analytics beacon', () => {
+  it('injects the Cloudflare beacon script', () => {
+    const { container } = render(
+      <RootLayout>
+        <div>content</div>
+      </RootLayout>
+    );
+
+    const beacon = container.querySelector(
+      'script[src="https://static.cloudflareinsights.com/beacon.min.js"]'
+    );
+    expect(beacon).not.toBeNull();
+  });
+
+  it('configures the beacon with the Ansible site token', () => {
+    const { container } = render(
+      <RootLayout>
+        <div>content</div>
+      </RootLayout>
+    );
+
+    const beacon = container.querySelector<HTMLScriptElement>(
+      'script[src="https://static.cloudflareinsights.com/beacon.min.js"]'
+    );
+    const beaconConfig = beacon?.getAttribute('data-cf-beacon');
+    expect(beaconConfig).toBeTruthy();
+    const parsed = JSON.parse(beaconConfig as string);
+    expect(parsed.token).toBe('352ed335bdae446cbc1c9ac0bebc2716');
+  });
+
+  it('loads the beacon with defer so it does not block rendering', () => {
+    const { container } = render(
+      <RootLayout>
+        <div>content</div>
+      </RootLayout>
+    );
+
+    const beacon = container.querySelector<HTMLScriptElement>(
+      'script[src="https://static.cloudflareinsights.com/beacon.min.js"]'
+    );
+    expect(beacon?.hasAttribute('defer')).toBe(true);
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,8 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Empty string fallback is the CI-build-without-secret case: beacon ships
+  // inert (Cloudflare rejects unknown tokens without affecting page load).
   const cfAnalyticsToken = process.env.NEXT_PUBLIC_CF_ANALYTICS_TOKEN ?? '';
 
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${dmSans.variable} ${newsreader.variable}`}>
-      <body>{children}</body>
+      <body>
+        {children}
+        <script
+          defer
+          src="https://static.cloudflareinsights.com/beacon.min.js"
+          data-cf-beacon='{"token": "352ed335bdae446cbc1c9ac0bebc2716"}'
+        />
+      </body>
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,9 @@
 // ABOUT: Root layout component for Ansible AI Reader
-// ABOUT: Defines HTML structure, global styles, and font variables for public pages
+// ABOUT: Defines HTML structure, global styles, and the Cloudflare Web Analytics beacon
 
 import type { Metadata } from 'next';
 import { DM_Sans, Newsreader } from 'next/font/google';
+import Script from 'next/script';
 import './globals.css';
 
 const dmSans = DM_Sans({
@@ -31,14 +32,16 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const cfAnalyticsToken = process.env.NEXT_PUBLIC_CF_ANALYTICS_TOKEN ?? '';
+
   return (
     <html lang="en" className={`${dmSans.variable} ${newsreader.variable}`}>
       <body>
         {children}
-        <script
-          defer
+        <Script
+          strategy="afterInteractive"
           src="https://static.cloudflareinsights.com/beacon.min.js"
-          data-cf-beacon='{"token": "352ed335bdae446cbc1c9ac0bebc2716"}'
+          data-cf-beacon={JSON.stringify({ token: cfAnalyticsToken })}
         />
       </body>
     </html>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -89,6 +89,10 @@ export default function PrivacyPage() {
               information unless you separately provide your email to access the demo. It is used
               solely for aggregate analytics (e.g. &ldquo;how many unique visitors this week&rdquo;).
             </p>
+            <p className="mt-3">
+              Separately, we also use Cloudflare Web Analytics to measure aggregate page traffic
+              and site performance. See &ldquo;Cookies and tracking&rdquo; below for details.
+            </p>
 
             <h3 className="font-semibold text-base text-foreground mt-6 mb-2">
               Demo engagement data

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -36,7 +36,7 @@ export default function PrivacyPage() {
         <h1 className="font-serif text-3xl sm:text-4xl font-medium mb-2">
           Privacy Policy
         </h1>
-        <p className="text-sm text-muted-foreground mb-12">Last updated: 5 April 2026</p>
+        <p className="text-sm text-muted-foreground mb-12">Last updated: 19 April 2026</p>
 
         <div className="prose prose-neutral max-w-none space-y-8 text-[15px] leading-relaxed text-foreground/85">
           <section>
@@ -162,10 +162,17 @@ export default function PrivacyPage() {
             </h2>
             <p>
               We do not use cookies. We use your browser&apos;s local storage to store a randomly
-              generated visitor identifier and session timing data. This data stays on your device
-              and is never sent to third parties. You can clear it at any time by clearing your
-              browser&apos;s local storage or site data. We do not use any third-party analytics
-              services.
+              generated visitor identifier and session timing data. This local storage data stays on
+              your device and is never sent to third parties. You can clear it at any time by
+              clearing your browser&apos;s local storage or site data.
+            </p>
+            <p className="mt-3">
+              We use Cloudflare Web Analytics to measure aggregate page traffic and site
+              performance. It is cookieless and does not fingerprint visitors — it aggregates
+              anonymous signals (URL path, referrer, approximate country, and device type) sent by
+              your browser when it loads a page. No individual visitor can be identified from this
+              data, and it is not combined with your email address or any information you provide
+              elsewhere on the site.
             </p>
           </section>
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -38,7 +38,9 @@ binding = "PROCESSING_QUEUE"
 #   - CLOUDFLARE_TURNSTILE_SECRET_KEY (contact form CAPTCHA server-side verification)
 #   - RESEND_FROM_EMAIL (contact form sender address — verified Resend domain)
 #   - CONTACT_EMAIL (contact form recipient — never exposed to client)
+#   - NEXT_PUBLIC_CF_ANALYTICS_TOKEN (Cloudflare Web Analytics public site token — also required at build time in CI)
 #
 # Note: CRON_SECRET is also required in the cron worker (wrangler-cron.toml)
 # Note: NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY must also be in the CI build step env (baked at build time)
+# Note: NEXT_PUBLIC_CF_ANALYTICS_TOKEN must also be in the CI build step env (baked at build time)
 # See REFERENCE/operations/environment-setup.md for values and configuration details.


### PR DESCRIPTION
## Summary

Two logically separate changes on this branch — kept together for a single review cycle but split into three commits for clean history.

### 1. Cloudflare Web Analytics beacon (initial commit `12833b6`, fixes in `d0c0e9d`)
- Ansible runs on Cloudflare Workers (not Pages), so automatic beacon injection does not apply — this adds a Next.js `<Script strategy="afterInteractive">` beacon to `src/app/layout.tsx` that loads on every route (public and authenticated), attributing pageviews and Core Web Vitals to `ansible.hultberg.org`
- Token comes from `NEXT_PUBLIC_CF_ANALYTICS_TOKEN` env var (matching the existing Turnstile pattern — three-touch registration in `.dev.vars.example`, `wrangler.toml` comment, and `deploy.yml` build step)
- **Privacy policy updated** (`src/app/privacy/page.tsx`) to accurately disclose Cloudflare Web Analytics — cookieless, non-fingerprinting, aggregate-only signals (path, referrer, approximate country, device type). "Last updated" bumped to 2026-04-19 per the policy's own change clause
- Captures pageviews and Core Web Vitals; no cookies / no PII / no consent banner needed (conditional on the accurate disclosure in the privacy policy)
- Tests verify beacon presence, token-from-env binding, `afterInteractive` strategy, and the empty-token CI-build fallback case (48 test files, 580 tests passing)
- Documented in `REFERENCE/operations/monitoring.md` and `REFERENCE/operations/environment-setup.md` — distinct from Supabase-backed admin analytics

### 2. `/review-spec` skill + supporting agents (commit `0e33a19`)
- New pre-implementation spec-review step mirroring the post-implementation `/review-pr-team` pattern
- Three challenger agents: `requirements-auditor`, `technical-skeptic`, `devils-advocate`
- New `technical-writer` agent wired into `/review-pr` and `/review-pr-team` for documentation completeness
- Root `CLAUDE.md` updated to insert the spec-review step into the standard Implementation Steps
- `REFERENCE/development/pr-review-workflow.md` brought current (previously stale — didn't mention `/review-spec`, still described `/review-pr-team` as 3 reviewers)

## ⚠️ Operational step required before merge-deploy

Add **`NEXT_PUBLIC_CF_ANALYTICS_TOKEN`** as a GitHub Actions secret (Settings → Secrets and variables → Actions). Without it, the production build will bake an empty token and the beacon will silently skip reporting. The token value is the one already present in the initial commit: `352ed335bdae446cbc1c9ac0bebc2716`. See `REFERENCE/operations/environment-setup.md` for details.

## Test plan
- [x] `npm test` — 48 test files, 580 tests passing (7 new layout tests, was 4)
- [x] `npx tsc --noEmit` — clean
- [x] All review-identified Criticals and Warnings addressed (see follow-up comment)
- [ ] Before merging: add `NEXT_PUBLIC_CF_ANALYTICS_TOKEN` as a GitHub Actions secret
- [ ] After merge + deploy, verify beacon traffic appears in Cloudflare Dashboard → Analytics & Logs → Web Analytics → `ansible.hultberg.org` within ~1 minute of a real pageview
- [ ] Spot-check Network tab in browser devtools: `beacon.min.js` should load with 200 status and a non-empty `data-cf-beacon` token attribute
- [ ] Verify no hydration warnings in the browser console for the `<Script>` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)