### PR TITLE
chore: Tighten spec-review agent prompts to project context

### DIFF
--- a/.claude/agents/devils-advocate.md
+++ b/.claude/agents/devils-advocate.md
@@ -44,7 +44,7 @@ Ask: What does the user actually need? What problem are they experiencing? Could
 
 - [ ] Is the problem statement clear and correct?
 - [ ] Is this solving the actual problem, or a proxy for it?
-- [ ] What evidence exists that this problem matters to users?
+- [ ] What concrete scenario or workflow gap motivated this? (a specific case beats abstract "users would want this")
 - [ ] Could the problem be solved by improving an existing feature rather than building a new one?
 
 ### Solution Fit
@@ -64,7 +64,7 @@ Ask: What does the user actually need? What problem are they experiencing? Could
 
 ### Scope and Prioritisation
 
-- [ ] Does this fit the current product priorities?
+- [ ] Does this fit the project's stated scope and purpose (depth-of-engagement triage of Reader content)?
 - [ ] Is the scope right? Too large? Missing important parts?
 - [ ] Is there a smaller version of this that would deliver 80% of the value?
 - [ ] Are there higher-priority problems this effort could address instead?

--- a/.claude/agents/requirements-auditor.md
+++ b/.claude/agents/requirements-auditor.md
@@ -55,7 +55,7 @@ Read the spec file provided. Understand:
 - [ ] What happens with empty states (no data, first use)?
 - [ ] What happens with boundary values (maximum, minimum, zero, null)?
 - [ ] What happens if the user performs actions out of the expected order?
-- [ ] What happens on concurrent access (two users doing the same thing simultaneously)?
+- [ ] What happens on concurrent access (cron worker firing a sync while the user clicks Sync, the same user with multiple tabs open, or the queue consumer processing a job while the user mutates the same row)?
 
 ### Data and State
 


### PR DESCRIPTION
## Summary

Three line-level reframes that remove generic-template wording from the `/review-spec` agent prompts. The previous wording was imported from a multi-person product-team template and didn't fit a solo-developer personal project with a cron+queue+web architecture.

- **`devils-advocate.md` line 47** — replaced *"What evidence exists that this problem matters to users?"* with a prompt for the concrete scenario that motivated the spec. The plural-users framing was load-bearing in the template but lands flat here, where the userbase is small and known.
- **`devils-advocate.md` line 67** — replaced *"Does this fit the current product priorities?"* (presumes a roadmap/PM-priority structure) with *"Does this fit the project's stated scope and purpose (depth-of-engagement triage of Reader content)?"* — the project's actual stated purpose from CLAUDE.md.
- **`requirements-auditor.md` line 58** — replaced *"two users doing the same thing simultaneously"* (low-relevance scenario) with the real concurrency model in this app: cron worker vs manual Sync, multiple tabs for the same user, queue consumer mutating a row the user is also editing. This is the change most likely to surface real bugs in future spec reviews — the previous wording surfaced theoretical ones.

## Why these and not others

Audited all three spec-review agents end-to-end. `technical-skeptic.md` was already well-tailored in `a3dbf91` (its checklists explicitly call out Readwise / Perplexity / Cloudflare Workers / Supabase / Resend) and needed no changes. The other two had only one cosmetic project-name mention each — their bodies were still mostly stock-template prose. These three lines were the only ones with genuine misfit; everything else was either correctly tailored or universal-enough to apply.

## Scope notes

- No code, schema, or behaviour change — prompt text only.
- No tests added/changed — agent `.md` files have no test surface.
- The agents are spawned by `/review-spec`, so the next time you run that skill you'll see the tightened prompts in action.

## Test plan

- [ ] Diff reads as three single-line reframes, two files
- [ ] No code or config touched (only `.claude/agents/*.md`)
- [ ] Optionally run `/review-spec` against any spec in `SPECIFICATIONS/` to sanity-check that the agents still load and the new wording reads naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)